### PR TITLE
AlertType and DeviceType dbManagement tabs

### DIFF
--- a/dashboard/public/javascripts/dbManagement/alertType.js
+++ b/dashboard/public/javascripts/dbManagement/alertType.js
@@ -26,8 +26,7 @@ jQuery(document).ready(($) => {
 
             $("#alertTypeTableBody #editButton" + alertType.id).click(function () {
                 $.post("/edit-alert-type", {id: alertType.id}, function () {
-                    $('html, body').animate({scrollTop: 0}, 'fast', function () {
-                    });
+                    $('html, body').animate({scrollTop: 0}, 'fast', function () {});
                     $("#alertTypeContent #submitFormButton").html("Update");
                     $("#alertTypeContent #clearFormButton").html("Cancel Edit");
                     $("#alertTypeContent .form-group #name").val($("#alertTypeTableBody #name" + alertType.id).html());


### PR DESCRIPTION
First try at a pull request with a feature branch.  Since I had been working off of the dev branch, there are virtually no changes between these two branches, so it might be a little hard to find the changes this time around.  

The overall changes are
- dbManagement option added in the main navbar
- tabs added to the dbManagement page for each db table
- AlertType form and table fully functional
- DeviceType form and table fully functional 