### PR TITLE
feature fix device info alert condition table

### DIFF
--- a/dashboard/public/javascripts/deviceInfo/deviceAlertConditions.js
+++ b/dashboard/public/javascripts/deviceInfo/deviceAlertConditions.js
@@ -48,14 +48,11 @@ jQuery(document).ready(($) => {
         await getAlertConditions();
 
         foundAlertConditions.forEach((alertCondition) => {
-            $.get("/alert-type", {id: alertCondition.alertTypeId}, (alertType) => {
-                alertType = JSON.parse(alertType);
-                let newRow = "<tr>" +
-                    "   <td>" + makeVariablesString(alertCondition.variables) + "</td>" +
-                    "   <td>" + alertType.name + "</td>" +
-                    "</tr>";
-                conditionsTable.row.add($(newRow)).draw();
-            });
+            let newRow = "<tr>" +
+                "   <td>" + makeVariablesString(alertCondition.variables) + "</td>" +
+                "   <td>" + alertCondition.alertTypeName + "</td>" +
+                "</tr>";
+            conditionsTable.row.add($(newRow)).draw();
         });
     }
 


### PR DESCRIPTION
The device info page was not updated based on the most recent alert condition model changes and the table was not displaying properly.  Small fix to make the table display the new alert conditions.